### PR TITLE
Provide way to get stack of logged Error objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ logger.notifications = ['error', 'warn', 'success'];
 
 // Prepend the notifications title
 logger.notificationsTitle = 'My App'
+
+// Dump stacks of Error objects as the first argument to error or warning
+logger.dumpStacks = true // 'blue' etc for your choice of color
 ```
+
+`loggy` takes the default value for `dumpStacks` from the `LOGGY_STACKS` environment variable.
 
 Methods:
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ const logger = {
   // May be used for setting correct process exit code.
   errorHappened: false,
 
+  // Dump stacks on errors
+  dumpStacks: process.env.LOGGY_STACKS !== undefined,
+
   // Creates new colored log entry.
   // Example:
   //
@@ -79,6 +82,10 @@ const logger = {
 
     if (level === 'error' || level === 'warn') {
       console.error.apply(console, all);
+      if (args[0] instanceof Error && logger.dumpStacks) {
+        let color = colors[logger.dumpStacks] || colors.brightBlack;
+        console.error(color(args[0].stack));
+      }
     } else {
       console.log.apply(console, all);
     }


### PR DESCRIPTION
`brunch` is failing with:

> 30 Mar 06:11:23 - error: [TypeError: Cannot read property 'split' of undefined] 

… and I can't figure out why without a stack trace. So, here's a way to get a stack trace.

This patch plus `env LOGGY_STACKS=blue brunch build` →

> TypeError: Cannot read property 'split' of undefined
>  at path (/Users/garth/src/konduko/core/node_modules/deppack/lib/module-naming.js:21:21)
>  at filePath (/Users/garth/src/konduko/core/node_modules/deppack/lib/module-naming.js:31:20)

Much better.