### PR TITLE
Cut the notification on Windows to avoid ENAMETOOLONG

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@ const logger = {
     const title = logger._title;
 
     if (types[level]) {
-      growl(args.join(' '), {title: title + capitalize(level)});
+      let string = args.join(' ');
+      const isWin = /^win/.test(process.platform);
+      // cut the notification on windows to 5000 chars to avoid the ENAMETOOLONG error (https://github.com/brunch/brunch/issues/1354)
+      if (isWin) string = string.slice(0, 5000);
+      growl(string, {title: title + capitalize(level)});
     }
   },
 


### PR DESCRIPTION
Closes brunch/brunch#1354

We could address this in `node-growl` but:

1. the `growlnotify` binary does not support piping
2. the `node-growl` library shouldn't probably make any assumptions about notif size

Therefore, it seems we should address this on the loggy level instead.

I have tried various message sizes, the notification itself stops to show at 9k chars, but does not error until about 33k. I'm cutting it to 5k here in order to account for possibility of title/etc also taking some tangible amount of chars.