### PR TITLE
Disable notification in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Params:
   Can be object, like `{error: 'red', log: 'cyan'}` or `false` (disables colors).
 * `logger.errorHappened` - `false`, changes to `true` if any error was logged.
 * `logger.notifications` - As Boolean, enables or disables notifications for errors, or
-  as Array, list types to trigger notifications, like `['error', 'warn', 'success']`.
+  as Array, list types to trigger notifications, like `['error', 'warn', 'success']`. Disabled
+  in production mode `NODE_ENV=production` by default.
 * `logger.notificationsTitle` - String, optional, prepends title in notifications.
 
 ## License

--- a/index.js
+++ b/index.js
@@ -19,15 +19,16 @@ const prettifyErrors = err => {
 const bell = '\x07';
 const initTime = today();
 const stackSuppressed = chalk.gray('\nStack trace was suppressed. Run with `LOGGY_STACKS=1` to see the trace.');
+const notifications = {
+  app: 'Loggy',
+  icon: `${__dirname}/logo.png`,
+  levels: ['error'],
+  notify,
+};
 
 const logger = {
   // Enables or disables system notifications for errors.
-  notifications: {
-    app: 'Loggy',
-    icon: `${__dirname}/logo.png`,
-    levels: ['error'],
-    notify,
-  },
+  notifications: process.env.NODE_ENV !== 'production' && notifications,
 
   // Colors that will be used for various log levels.
   colors: {


### PR DESCRIPTION
Hello.

Running my app in production I have encountered a very distracting bug, which I've tracked down to the loggy. It tries to spawn a child process for displaying notification, but the server environment doesn't have proper tools for it, and node crashes. 

I say that this notification system should be disabled in production mode by default. What do you think about it?