### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Colorful stdstream dead-simple logger for node.js.
 
 * Logs stuff to stdout (`log`, `info`, `success`).
 * Logs errors & warnings to stderr (`warn`, `error`).
-* Adds colors to log types (e.g. `warn`, `info` words will be colored). Uses [chalk](https://github.com/chalk/chalk).
+* Adds colors to log types (e.g. `warn`, `info` words will be colored). Uses [Turbocolor](https://github.com/jorgebucaran/turbocolor).
 * Emits system notifications for errors with [native-notifier](https://github.com/paulmillr/native-notifier).
 * Tracks whether any error was logged (useful for changing process exit code).
 * No 3rd-party deps (Growl etc.)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const notify = require('native-notifier');
-const Chalk = require('chalk').constructor;
-const chalk = new Chalk('FORCE_NO_COLOR' in process.env && {enabled: false});
+const turbo = require('turbocolor');
+turbo.enabled = !('FORCE_NO_COLOR' in process.env);
 
 const today = () => new Date().setHours(0, 0, 0, 0);
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
@@ -11,14 +11,14 @@ const prettifyErrors = err => {
   if (!logger.dumpStacks) return err.message + stackSuppressed;
 
   const stack = err.stack.slice(err.stack.indexOf('\n'));
-  const color = chalk[logger.dumpStacks] || chalk.gray;
+  const color = turbo[logger.dumpStacks] || turbo.gray;
 
   return err.message + color(stack);
 };
 
 const bell = '\x07';
 const initTime = today();
-const stackSuppressed = chalk.gray('\nStack trace was suppressed. Run with `LOGGY_STACKS=1` to see the trace.');
+const stackSuppressed = turbo.gray('\nStack trace was suppressed. Run with `LOGGY_STACKS=1` to see the trace.');
 
 const logger = {
   // Enables or disables system notifications for errors.
@@ -58,7 +58,7 @@ const logger = {
     const colors = logger.colors;
     if (colors === Object(colors)) {
       const color = colors[level];
-      const paint = chalk[color];
+      const paint = turbo[color];
       if (typeof paint === 'function') level = paint(level);
     }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Paul Miller (paulmillr.com)",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.1.1",
+    "turbocolor": "^2.2.0",
     "native-notifier": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello @paulmillr! 👋 

This PR just swaps chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor). It ought to give you a perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API (see [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)). 

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

Let me know if this is acceptable to you. Cheers!